### PR TITLE
Add UDS support for tonic gRPC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,9 @@ tonic = "0.8"
 prost = "0.11"
 futures-core = "0.3"
 futures-util = "0.3"
-tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "sync", "time"] }
-tokio-stream = "0.1"
+tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "sync", "time", "net", "fs"] }
+tokio-stream = { version = "0.1", features = ["net"] }
+tower = { version = "0.4" }
 log = "0.4.17"
 nispor = "1.2.7"
 clap = { version = "3.0.12", features = ["derive"] }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -35,12 +35,11 @@ impl LeaseCache {
         let fq_path = Path::new(dir.as_deref().unwrap_or(DEFAULT_CACHE_DIR)).join("nv-leases");
         debug!("lease cache file: {:?}", fq_path.to_str().unwrap_or(""));
 
-        // TODO Should LeaseCache use the resulting file from here instead of a path?
-        // let cache_file = OpenOptions::new().write(true).create(true).open(fq_path)?;
+        OpenOptions::new().write(true).create(true).open(&fq_path)?;
 
         Ok(LeaseCache {
             mem: HashMap::new(),
-            path: fq_path.clone(),
+            path: fq_path,
         })
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,16 +1,20 @@
 use clap::{Parser, Subcommand};
+use http::Uri;
 use log::debug;
-
+use tokio::net::UnixStream;
+use tonic::transport::Endpoint;
+use tower::service_fn;
 //    ** This client represents the netavark binary which will establish a connection **
 use netavark_proxy::commands::{setup, teardown};
 use netavark_proxy::g_rpc::netavark_proxy_client::NetavarkProxyClient;
+use netavark_proxy::{DEFAULT_NETWORK_CONFIG, DEFAULT_UDS_PATH};
 
 #[derive(Parser, Debug)]
 #[clap(version = env!("CARGO_PKG_VERSION"))]
 struct Opts {
-    /// Use specific grpc_port
+    /// Use specific uds path
     #[clap(short, long)]
-    port: Option<String>,
+    uds: Option<String>,
     /// Instead of reading from STDIN, read the configuration to be applied from the given file.
     #[clap(short, long)]
     file: Option<String>,
@@ -29,25 +33,33 @@ enum SubCommand {
     // Version(version::Version),
 }
 
-pub const XDGRUNTIME: &str = "/run/user/1000/nv-leases";
+#[cfg(unix)]
 #[tokio::main]
-#[allow(unused)]
 // This client assumes you use the default lease directory
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // This should be moved to somewhere central.  We also need to add override logic.
-    let default_uri = String::from("http://[::1]:10000");
 
     env_logger::builder().format_timestamp(None).init();
     let opts = Opts::parse();
-    let file = opts.file.unwrap_or_else(|| String::from("/dev/stdin"));
-    let grpc_port = opts.port.unwrap_or(default_uri);
+    let file = opts.file.unwrap_or(DEFAULT_NETWORK_CONFIG.to_string());
+    let uds_path = opts.uds.unwrap_or(DEFAULT_UDS_PATH.to_string());
 
-    debug!("using grpc port: {}", grpc_port);
+    // We will ignore this uri because uds do not use it
+    // if your connector does use the uri it will be provided
+    // as the request to the `MakeConnection`.
+    let channel = Endpoint::try_from("http://[::1]:10000")?
+        .connect_with_connector(service_fn(move |_: Uri| {
+            // Connect to a Uds socket
+            let path = uds_path.clone();
+            debug!("using uds path: {}", &path);
+            UnixStream::connect(path)
+        }))
+        .await?;
 
     let input_config = netavark_proxy::g_rpc::NetworkConfig::load(&file)?;
     println!("{:?}", ::serde_json::to_string_pretty(&input_config));
 
-    let mut client = NetavarkProxyClient::connect(grpc_port).await?;
+    let client = NetavarkProxyClient::new(channel);
 
     let result = match opts.subcmd {
         SubCommand::Setup(_) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,13 @@ use std::error::Error;
 pub mod cache;
 pub mod commands;
 use std::fs::File;
+// TODO these constant destinations are not final.
+// Default UDS path for gRPC to communicate on.
+pub const DEFAULT_UDS_PATH: &str = "/var/tmp/nv-dhcp";
+// Default configuration directory.
+pub const DEFAULT_CONFIG_DIR: &str = "";
+// Default Network configuration path
+pub const DEFAULT_NETWORK_CONFIG: &str = "/dev/stdin";
 
 pub mod g_rpc {
     include!("../proto-build/netavark_proxy.rs");


### PR DESCRIPTION
gRPC messaging uses UDS instead of default HTTP/2. This includes removing the UDS file after exit of the server.

Signed-off-by: Jack <jackbaude@gmail.com>