### PR TITLE
Change mac address to string

### DIFF
--- a/proto/proxy.proto
+++ b/proto/proxy.proto
@@ -3,13 +3,13 @@ package netavark_proxy;
 
 service NetavarkProxy {
   rpc Setup(NetworkConfig) returns (Lease) {}
-  rpc Teardown(MacAddress) returns (Lease) {}
+  rpc Teardown(NetworkConfig) returns (Lease) {}
   rpc Clean(Empty) returns (OperationResponse) {}
 }
 // Netavark sends the proxy the Network Configuration that it wants to setup
 message NetworkConfig {
   string iface = 1;
-  MacAddress mac_addr = 3;
+  string mac_addr = 3;
   string domain_name = 4;
   string host_name = 5;
   Version version = 6;
@@ -22,7 +22,7 @@ message Lease {
   uint32 lease_time = 3;
   uint32  mtu = 4;
   string domain_name = 5;
-  MacAddress mac_addr = 6;
+  string mac_address= 6;
   bool isV6 = 10;
   DhcpV4Lease v4 = 11;
   DhcpV6Lease v6 = 12;
@@ -55,10 +55,6 @@ message OperationResponse {
 enum Version {
   V4 = 0;
   V6 = 1;
-}
-
-message MacAddress {
-  string addr = 1;
 }
 
 message Ipv4Addr {

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -25,7 +25,7 @@ impl FromStr for NetworkConfig {
         // instead of default empty values
         Ok(NetworkConfig {
             iface: "".to_string(),
-            mac_addr: None,
+            mac_addr: "".to_string(),
             domain_name: "".to_string(),
             host_name: "".to_string(),
             version: 0,


### PR DESCRIPTION
previous implementations of mac address had it as a nested structure
which turned out to be unnecessary.

Signed-off-by: Brent Baude <bbaude@redhat.com>