### PR TITLE
Clippy to not allow unwaps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,4 +60,5 @@ integration: $(CARGO_TARGET_DIR)
 .PHONY: validate
 validate: $(VARGO_TARGET_DIR)
 	cargo fmt --all -- --check
-	cargo clippy --no-deps --fix --
+	cargo clippy --no-deps --fix --allow-dirty -- \
+		-W clippy::unwrap_used

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub const DEFAULT_UDS_PATH: &str = "/var/tmp/nv-dhcp";
 pub const DEFAULT_CONFIG_DIR: &str = "";
 // Default Network configuration path
 pub const DEFAULT_NETWORK_CONFIG: &str = "/dev/stdin";
-
+#[allow(clippy::unwrap_used)]
 pub mod g_rpc {
     include!("../proto-build/netavark_proxy.rs");
     use mozim::DhcpV4Lease as MozimV4Lease;


### PR DESCRIPTION
Do not allow unwraps, instead use expects if necessary. Ignore protobuff generated code. Allow dirty for clippy so that validate can run without a commit.

Signed-off-by: Jack <jackbaude@gmail.com>