### PR TITLE
Separate DHCP DORA from gRPC server.

### DIFF
--- a/src/dhcp_service.rs
+++ b/src/dhcp_service.rs
@@ -1,0 +1,169 @@
+use crate::dhcp_service::DhcpServiceErrorKind::{Bug, InvalidArgument, NoLease, Timeout};
+use crate::g_rpc::{Lease as NetavarkLease, NetworkConfig};
+use mozim::{DhcpV4Client, DhcpV4Config, DhcpV4Lease as MozimV4Lease};
+use tonic::{Code, Status};
+
+/// The kind of DhcpServiceError that can be caused when finding a dhcp lease
+pub enum DhcpServiceErrorKind {
+    Timeout,
+    InvalidArgument,
+    InvalidDhcpServerReply,
+    NoLease,
+    Bug,
+    LeaseExpired,
+}
+/// A DhcpServiceError is an error caused in the process of finding a dhcp lease
+pub struct DhcpServiceError {
+    kind: DhcpServiceErrorKind,
+    msg: String,
+}
+
+impl DhcpServiceError {
+    pub fn new(kind: DhcpServiceErrorKind, msg: String) -> Self {
+        DhcpServiceError { kind, msg }
+    }
+}
+
+/// The dhcp client can either be a Ipv4 or Ipv6.
+///
+/// These clients are managed differently. so it is important to keep these separate.
+pub enum DhcpClient {
+    V4Client(Box<DhcpV4Client>),
+    V6Client(/*TODO implement v6 client*/),
+}
+/// DHCP service is responsible for creating, handling, and managing the dhcp lease process.
+pub struct DhcpService {
+    client: Option<DhcpClient>,
+    network_config: NetworkConfig,
+    timeout: isize,
+}
+
+impl DhcpService {
+    pub fn new(nc: NetworkConfig, timeout: isize) -> Result<DhcpService, DhcpServiceError> {
+        let client = Self::create_client(&nc)?;
+        Ok(DhcpService {
+            client: Some(client),
+            network_config: nc,
+            timeout,
+        })
+    }
+    /// Based on the IP version, use the dhcp client to process a dhcp lease using DORA.
+    /// Note: By using process you pass ownership of the dhcp service.
+    pub fn get_lease(mut self) -> Result<NetavarkLease, DhcpServiceError> {
+        // match the ip version to create the correct dhcp client
+        if let Some(client) = self.client.take() {
+            return match client {
+                DhcpClient::V4Client(v4_client) => self.get_v4_lease(*v4_client),
+                DhcpClient::V6Client() => self.get_v6_lease(),
+            };
+        }
+        Err(DhcpServiceError::new(
+            Bug,
+            "Could not initiate dhcp client".to_string(),
+        ))
+    }
+
+    /// Performs a DHCP DORA on a ipv4 network configuration.
+    /// # Arguments
+    ///
+    /// * `client`: a IPv4 mozim dhcp client. When this method is called, it takes ownership of client.
+    ///
+    /// returns: Result<Lease, DhcpSearchError>. Either finds a lease successfully, finds no lease, or fails
+    fn get_v4_lease(&self, mut client: DhcpV4Client) -> Result<NetavarkLease, DhcpServiceError> {
+        let timeout = self.timeout;
+        let events = match client.poll(timeout) {
+            Ok(events) => events,
+            Err(dhcp_error) => {
+                log::error!("DHCP socket timed out: {}", dhcp_error.to_string());
+                return Err(DhcpServiceError::new(Timeout, dhcp_error.to_string()));
+            }
+        };
+        // Process the DHCP events after the socket has blocked
+        for event in events {
+            match client.process(event) {
+                Ok(Some(new_lease)) => {
+                    log::debug!("successfully found a lease");
+                    let mut netavark_lease = <NetavarkLease as From<MozimV4Lease>>::from(new_lease);
+                    netavark_lease.add_domain_name(&self.network_config.domain_name);
+                    netavark_lease.add_mac_address(&self.network_config.mac_addr);
+                    return Ok(netavark_lease);
+                }
+                Err(err) => return Err(DhcpServiceError::new(NoLease, err.to_string())),
+                Ok(None) => { /*No lease found, keep looking for one*/ }
+            };
+        }
+        log::error!("Could not find a lease");
+        Err(DhcpServiceError::new(
+            NoLease,
+            "Could not find a lease".to_string(),
+        ))
+    }
+    /// TODO
+    /// Performs a DHCP DORA on a IPv6 network configuration.
+    /// # Arguments
+    ///
+    /// * `client`: a Ipv6 mozim dhcp client. When this method is called, it takes ownership of client.
+    ///
+    /// returns: Result<NetavarkLease, DhcpSearchError>. Either finds a lease successfully, finds no lease, or fails
+    fn get_v6_lease(&self) -> Result<NetavarkLease, DhcpServiceError> {
+        log::error!("ipv6 dhcp requests are unimplemented.");
+        Err(DhcpServiceError::new(
+            Bug,
+            "ipv6 dhcp requests are unimplemented.".to_string(),
+        ))
+    }
+
+    /// Create a DHCP client
+    /// # Arguments
+    ///
+    /// * `iface`: network interface name
+    /// * `version`: Version - can be Ipv4 or Ipv6
+    ///
+    /// returns: Result<DhcpV4Client, DhcpError>. If there are no invalid arguments, mozim creates a client.
+    fn create_client(nc: &NetworkConfig) -> Result<DhcpClient, DhcpServiceError> {
+        let version = &nc.version;
+        let iface = &nc.iface;
+        match version {
+            //V4
+            0 => {
+                let config = match DhcpV4Config::new(iface) {
+                    Ok(config) => config,
+                    Err(err) => {
+                        return Err(DhcpServiceError::new(InvalidArgument, err.to_string()))
+                    }
+                };
+                match DhcpV4Client::init(config, None) {
+                    Ok(client) => Ok(DhcpClient::V4Client(Box::new(client))),
+                    Err(err) => Err(DhcpServiceError::new(InvalidArgument, err.to_string())),
+                }
+            }
+            //V6 TODO implement DHCPv6
+            1 => {
+                unimplemented!();
+            }
+            // No valid version found in the network configuration sent by the client
+            _ => Err(DhcpServiceError::new(
+                InvalidArgument,
+                String::from("Must select a valid IP protocol 0=v4, 1=v6"),
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for DhcpServiceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.msg)
+    }
+}
+
+impl From<DhcpServiceError> for Status {
+    fn from(err: DhcpServiceError) -> Self {
+        match err.kind {
+            Timeout => Status::new(Code::Aborted, err.msg),
+            InvalidArgument => Status::new(Code::InvalidArgument, err.msg),
+            NoLease => Status::new(Code::NotFound, err.msg),
+            Bug => Status::new(Code::Internal, err.msg),
+            _ => Status::new(Code::Internal, err.msg),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@ use std::error::Error;
 
 pub mod cache;
 pub mod commands;
+pub mod dhcp_service;
+
 use std::fs::File;
 // TODO these constant destinations are not final.
 // Default UDS path for gRPC to communicate on.
@@ -11,6 +13,8 @@ pub const DEFAULT_UDS_PATH: &str = "/var/tmp/nv-dhcp";
 pub const DEFAULT_CONFIG_DIR: &str = "";
 // Default Network configuration path
 pub const DEFAULT_NETWORK_CONFIG: &str = "/dev/stdin";
+// Default epoll wait time before dhcp socket times out
+pub const DEFAULT_TIMEOUT: isize = 8;
 #[allow(clippy::unwrap_used)]
 pub mod g_rpc {
     include!("../proto-build/netavark_proxy.rs");
@@ -18,12 +22,12 @@ pub mod g_rpc {
 
     impl Lease {
         /// Add mac address to a lease
-        pub fn add_mac_address(&mut self, mac_addr: &str) {
+        pub fn add_mac_address(&mut self, mac_addr: &String) {
             self.mac_address = mac_addr.to_string()
         }
         /// Update the domain name of the lease
-        pub fn add_domain_name(&mut self, domain_name: String) {
-            self.domain_name = domain_name;
+        pub fn add_domain_name(&mut self, domain_name: &String) {
+            self.domain_name = domain_name.to_string();
         }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,9 +1,8 @@
 #![cfg_attr(not(unix), allow(unused_imports))]
-use mozim::{DhcpError, DhcpV4Client, DhcpV4Config, DhcpV4Lease as MozimV4Lease, ErrorKind};
 use netavark_proxy::cache::LeaseCache;
 use netavark_proxy::g_rpc::netavark_proxy_server::{NetavarkProxy, NetavarkProxyServer};
 use netavark_proxy::g_rpc::{Empty, Lease as NetavarkLease, NetworkConfig, OperationResponse};
-use netavark_proxy::{DEFAULT_CONFIG_DIR, DEFAULT_UDS_PATH};
+use netavark_proxy::{DEFAULT_CONFIG_DIR, DEFAULT_TIMEOUT, DEFAULT_UDS_PATH};
 use std::fs;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -14,9 +13,8 @@ use tokio_stream::wrappers::UnixListenerStream;
 
 use clap::Parser;
 use log::{debug, warn};
-use tonic::{transport::Server, Code, Code::Internal, Request, Response, Status};
-
-const POLL_WAIT_TIME: isize = 5;
+use netavark_proxy::dhcp_service::DhcpService;
+use tonic::{transport::Server, Code::Internal, Request, Response, Status};
 
 #[derive(Debug)]
 /// This is the tonic netavark proxy service that is required to impl the Netavark Proxy trait which
@@ -30,78 +28,39 @@ const POLL_WAIT_TIME: isize = 5;
 ///    tonic creates its own runtime for each request and mozim trys to make its own runtime inside of
 ///    a runtime.
 ///
-struct NetavarkProxyService(Arc<Mutex<LeaseCache>>);
+struct NetavarkProxyService(Arc<Mutex<LeaseCache>>, isize);
 
 // gRPC request and response methods
 #[tonic::async_trait]
 impl NetavarkProxy for NetavarkProxyService {
-    /// A new lease will be sent back to netavark on request. get_lease() is responsible for also
-    /// updating the cache based on the dhcp event that happens.
+    /// gRPC connection to get a lease
     async fn setup(
         &self,
         request: Request<NetworkConfig>,
     ) -> Result<Response<NetavarkLease>, Status> {
         debug!("Request from client {:?}", request.remote_addr());
-        //Spawn a new thread to avoid tokio runtime issues
+
         let cache = self.0.clone();
+        let timeout = self.1.clone();
+        //Spawn a new thread to avoid tokio runtime issues
         std::thread::spawn(move || {
             // Set up some common values
-            let network_config: NetworkConfig = request.into_inner();
-            println!("{:#?}", serde_json::to_string_pretty(&network_config));
-            // Make sure a mac address was supplied in the NetworkConfig and validate the addr if it exists
-            let mac_addr = network_config.mac_addr;
-
-            // DHCP client will be in charge of making the DORA requests to the DHCP server
-            let mut client = match get_client(&network_config.iface, &network_config.version) {
-                Ok(c) => c,
-                Err(e) => return Err(Status::new(Internal, e.to_string())),
-            };
-            // Attempt to process for a lease 31 times. Sleep for a second every 8 attempts
-            for i in 1..31 {
-                let events = match client.poll(POLL_WAIT_TIME) {
-                    Ok(events) => events,
-                    Err(dhcp_error) => {
-                        log::error!("Error polling DHCP: {}", dhcp_error.to_string());
-                        return Err(Status::new(Internal, dhcp_error.to_string()));
-                    }
-                };
-                for event in events {
-                    match client.process(event) {
-                        // Lease successfully found
-                        Ok(Some(new_lease)) => {
-                            // the lease must be mutable in order to add the mac address and domain name
-                            let mut netavark_lease =
-                                <NetavarkLease as From<MozimV4Lease>>::from(new_lease);
-                            netavark_lease.add_mac_address(&mac_addr);
-                            netavark_lease.add_domain_name(network_config.domain_name);
-                            if let Err(e) = cache
-                                .lock()
-                                .expect("Could not unlock cache. A thread was poisoned")
-                                .add_lease(&mac_addr, &netavark_lease)
-                            {
-                                return Err(Status::new(
-                                    Internal,
-                                    format!("Error caching the lease: {}", e),
-                                ));
-                            }
-                            return Ok(Response::new(netavark_lease));
-                        }
-                        Err(err) => {
-                            return Err(Status::new(Internal, err.to_string()));
-                        }
-                        Ok(None) => {}
-                    };
-                }
-                // Sleep for one second every 8 attempts
-                if i % 8 == 0 {
-                    log::debug!("No DHCP response. Sleeping 1s");
-                    std::thread::sleep(std::time::Duration::from_secs(1));
-                }
+            let network_config = request.into_inner();
+            let mac_addr = network_config.mac_addr.clone();
+            // create a dhcp service to get a lease.
+            let lease = DhcpService::new(network_config, timeout)?.get_lease()?;
+            // Try and add the lease information to the cache
+            if let Err(e) = cache
+                .lock()
+                .expect("Could not unlock cache. A thread was poisoned")
+                .add_lease(&mac_addr, &lease)
+            {
+                return Err(Status::new(
+                    Internal,
+                    format!("Error caching the lease: {}", e),
+                ));
             }
-            Err(Status::new(
-                Code::Unavailable,
-                "Could not find a lease. Likely could not find a dhcp server",
-            ))
+            Ok(Response::new(lease))
         })
         .join()
         .expect("Error joining thread")
@@ -145,37 +104,6 @@ impl NetavarkProxy for NetavarkProxyService {
     }
 }
 
-/// Create a DHCP client using mozim. This method takes a interface name and version and generates
-/// a DHCP client that can be processed for DHCP events
-///
-/// # Arguments
-///
-/// * `iface`: network interface name
-/// * `version`: Version - can be Ipv4 or Ipv6
-///
-/// returns: Result<DhcpV4Client, DhcpError>
-///
-/// On success a DHCP client of the version type will be returned. On failure a DHCP error will be
-/// returned
-fn get_client(iface: &str, version: &i32) -> Result<DhcpV4Client, DhcpError> {
-    match version {
-        //V4
-        0 => {
-            let config = DhcpV4Config::new(iface)?;
-            let client = DhcpV4Client::init(config, None)?;
-            Ok(client)
-        }
-        //V6 TODO implement DHCPv6
-        1 => {
-            unimplemented!();
-        }
-        // No valid version found in the network configuration sent by the client
-        _ => Err(DhcpError::new(
-            ErrorKind::InvalidArgument,
-            String::from("Must select a valid IP protocol 0=v4, 1=v6"),
-        )),
-    }
-}
 #[derive(Parser, Debug)]
 #[clap(version = env!("CARGO_PKG_VERSION"))]
 struct Opts {
@@ -185,6 +113,9 @@ struct Opts {
     /// alternative uds location
     #[clap(short, long)]
     uds: Option<String>,
+    /// optional time in seconds to time out after looking for a lease
+    #[clap(short, long)]
+    timeout: Option<isize>,
 }
 
 #[tokio::main]
@@ -194,9 +125,12 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let opts = Opts::parse();
 
     // where we store the cache file
-    let conf_dir = opts.dir.unwrap_or_else(|| DEFAULT_CONFIG_DIR.to_string());
+    let conf_dir = opts.dir.unwrap_or(DEFAULT_CONFIG_DIR.to_string());
     // location of the grpc port
-    let uds_path = opts.uds.unwrap_or_else(|| DEFAULT_UDS_PATH.to_string());
+    let uds_path = opts.uds.unwrap_or(DEFAULT_UDS_PATH.to_string());
+    // timeout time if no leases are found
+    let timeout = opts.timeout.unwrap_or(DEFAULT_TIMEOUT);
+
     // Match because parent reruns an option
     match Path::new(&uds_path).parent() {
         None => {
@@ -216,7 +150,8 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             return Ok(());
         }
     };
-    let netavark_proxy_service = NetavarkProxyService(cache);
+    // let dhcp_service = DhcpService::new()
+    let netavark_proxy_service = NetavarkProxyService(cache, timeout);
     Server::builder()
         .add_service(NetavarkProxyServer::new(netavark_proxy_service))
         .serve_with_incoming(uds_stream)


### PR DESCRIPTION
By creating a custom dhcp service it will create more flexibility in how leases are acquired. The following items would benefit from this proposal, handling IPv4 and IPv6 DORA, custom timeout option for dhcp search, verbose DORA error messages.

fixes: https://github.com/containers/netavark-dhcp-proxy/issues/12.

Please test these changes locally to confirm dhcp is working. 

Signed-off-by: Jack <jackbaude@gmail.com>