### PR TITLE
Cirrus: Update CI VM Images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,7 +19,7 @@ env:
     NETAVARK_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/netavark-dhcp-proxy/success/binary.zip?branch=${NETAVARK_BRANCH}"
     # Save a little typing (path relative to $CIRRUS_WORKING_DIR)
     SCRIPT_BASE: "./contrib/cirrus"
-    IMAGE_SUFFIX: "c6372887002087424"
+    IMAGE_SUFFIX: "c6535313974624256"
     FEDORA_NETAVARK_IMAGE: "fedora-netavark-${IMAGE_SUFFIX}"
 
 

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -30,3 +30,7 @@ show_env_vars
 #    mv netavark.$(uname -m)-unknown-linux-gnu netavark
 #fi
 #chmod a+x /usr/libexec/podman/netavark
+
+# Warning, this isn't the end.  An exit-handler is installed to finalize
+# setup of env. vars.  This is required for runner.sh to operate properly.
+# See complete_setup() in lib.sh for details.


### PR DESCRIPTION
**Depends on:**  https://github.com/containers/netavark/pull/431

These images have built-in rust toolchain and clipy linter.

Ref:
  https://github.com/containers/automation_images/pull/214

Signed-off-by: Chris Evich <cevich@redhat.com>