### PR TITLE
Configure IP and route in namespace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,9 @@ clap = { version = "3.0.12", features = ["derive"] }
 env_logger = "0.9.1"
 http = "0.2.8"
 macaddr = "1.0.1"
-netavark = { git = "https://github.com/containers/netavark", version="1.2.0-dev"}
+netavark = { git = "https://github.com/containers/netavark", rev="0b04857d9b3eea88029a1f03f418a2384913f679"}
+rtnetlink = "0.11.0" 
+ipnet = { version = "2", features = ["serde"] }
 
 [build-dependencies]
 tonic-build = "0.8"

--- a/proto/proxy.proto
+++ b/proto/proxy.proto
@@ -13,6 +13,7 @@ message NetworkConfig {
   string domain_name = 4;
   string host_name = 5;
   Version version = 6;
+  string ns_path = 7;
 
 }
 // Lease can either contain a IPv4 or IPv6 DHCP lease, and the common IP information
@@ -24,26 +25,17 @@ message Lease {
   string domain_name = 5;
   string mac_address= 6;
   bool isV6 = 10;
-  DhcpV4Lease v4 = 11;
-  DhcpV6Lease v6 = 12;
+  string siaddr = 11;
+  string yiaddr = 12;
+  string srv_id = 16;
+  string subnet_mask = 17;
+  string broadcast_addr = 18;
+  repeated string dns_servers = 19;
+  repeated string gateways = 20;
+  repeated string ntp_servers = 21;
+  string host_name = 22;
 }
 
-message DhcpV4Lease {
-  string siaddr = 1;
-  string yiaddr = 2;
-  string srv_id = 6;
-  string subnet_mask = 7;
-  string broadcast_addr = 8;
-  repeated string dns_servers = 9;
-  repeated string gateways = 10;
-  repeated string ntp_servers = 11;
-  string host_name = 13;
-}
-
-// Todo implement v6 lease
-message DhcpV6Lease {
-
-}
 // Empty Message to send when calling for a shutdown
 message Empty{}
 

--- a/src/dhcp_service.rs
+++ b/src/dhcp_service.rs
@@ -39,11 +39,11 @@ pub struct DhcpService {
 }
 
 impl DhcpService {
-    pub fn new(nc: NetworkConfig, timeout: isize) -> Result<DhcpService, DhcpServiceError> {
-        let client = Self::create_client(&nc)?;
+    pub fn new(nc: &NetworkConfig, timeout: isize) -> Result<DhcpService, DhcpServiceError> {
+        let client = Self::create_client(nc)?;
         Ok(DhcpService {
             client: Some(client),
-            network_config: nc,
+            network_config: nc.clone(),
             timeout,
         })
     }

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -1,0 +1,167 @@
+// use netavark::network::core_utils::CoreUtils;
+
+/*
+   This file is intended to support netavark-dhcp-proxy configuring the IP information
+   that it got from the dhcp server.
+
+   Long term this file/function should move into netavark
+*/
+
+use crate::g_rpc::{Lease as NetavarkLease, Lease};
+use crate::types::{CustomErr, ProxyError};
+use ipnet::IpNet;
+use log::debug;
+use netavark::network::core_utils;
+use netavark::network::netlink;
+use netavark::network::netlink::Socket;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::str::FromStr;
+
+trait IpConv {
+    fn to_v4(&self) -> Result<&Ipv4Addr, ProxyError>;
+    fn to_v6(&self) -> Result<&Ipv6Addr, ProxyError>;
+}
+
+// Simple implementation for converting from IPAddr to
+// specific IP type
+impl IpConv for IpAddr {
+    fn to_v4(&self) -> Result<&Ipv4Addr, ProxyError> {
+        match self {
+            IpAddr::V4(ip) => Ok(ip),
+            IpAddr::V6(_) => Err(ProxyError::new(
+                "invalid value for ipv4 conversion".to_string(),
+            )),
+        }
+    }
+
+    fn to_v6(&self) -> Result<&Ipv6Addr, ProxyError> {
+        match self {
+            IpAddr::V4(_) => Err(ProxyError::new(
+                "invalid value for ipv6 conversion".to_string(),
+            )),
+            IpAddr::V6(ip) => Ok(ip),
+        }
+    }
+}
+
+/*
+   Information that came back in the DHCP lease like name_servers,
+   domain and host names, etc. will be implemented in podman; not here.
+*/
+
+#[derive(Clone, Debug)]
+struct MacVLAN {
+    address: IpAddr,
+    gateways: Vec<IpNet>,
+    interface: String,
+    // Unset right now
+    // mtu: u32,
+    prefix_length: u8,
+}
+
+trait Address<T> {
+    fn new(l: &Lease, interface: &str) -> Result<Self, ProxyError>
+    where
+        Self: Sized;
+    fn add_ip(&self, nls: &mut Socket) -> Result<(), ProxyError>;
+    fn add_gws(&self, nls: &mut Socket) -> Result<(), ProxyError>;
+    fn remove(self) -> Result<(), ProxyError>;
+}
+
+fn handle_gws(g: Vec<String>, netmask: &str) -> Result<Vec<IpNet>, ProxyError> {
+    // TODO Need unit test
+    let mut gws = Vec::new();
+    for route in g {
+        // TODO FIX for ipv6
+        let sub_mask = match Ipv4Addr::from_str(netmask) {
+            Ok(n) => n,
+            Err(e) => return Err(ProxyError::new(e.to_string())),
+        };
+        let prefix = u32::from(sub_mask).count_ones();
+        let ip = match Ipv4Addr::from_str(&route) {
+            Ok(i) => i,
+            Err(e) => return Err(ProxyError::new(e.to_string())),
+        };
+        let gw = match IpNet::new(IpAddr::from(ip), prefix as u8) {
+            Ok(r) => r,
+            Err(e) => return Err(ProxyError::new(format!("{}:'{}'", e, route))),
+        };
+        gws.push(gw);
+    }
+    Ok(gws)
+}
+
+// IPV4 implementation
+impl Address<Ipv4Addr> for MacVLAN {
+    fn new(l: &NetavarkLease, interface: &str) -> Result<MacVLAN, ProxyError> {
+        debug!("new ipv4 macvlan for {}", interface);
+        let address = match IpAddr::from_str(&l.yiaddr) {
+            Ok(a) => a,
+            Err(e) => {
+                return Err(ProxyError::new(format!("bad address: {}", e)));
+            }
+        };
+        let gateways = match handle_gws(l.gateways.clone(), &l.subnet_mask) {
+            Ok(g) => g,
+            Err(e) => {
+                return Err(ProxyError::new(format!("bad gateways: {}", e.to_string())));
+            }
+        };
+
+        Ok(MacVLAN {
+            address,
+            gateways,
+            interface: interface.to_string(),
+            // Disabled for now
+            // mtu: l.mtu,
+            prefix_length: 0,
+        })
+    }
+
+    //  add the ip address to the container namespace
+    fn add_ip(&self, nls: &mut Socket) -> Result<(), ProxyError> {
+        debug!("adding network information for {}", self.interface);
+        let ip = IpNet::new(self.address, self.prefix_length)?;
+        let dev = nls.get_link(netlink::LinkID::Name(self.interface.clone()))?;
+        match nls.add_addr(dev.header.index, &ip) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(ProxyError::new(e.to_string())),
+        }
+    }
+
+    // add one or more routes to the container namespace
+    fn add_gws(&self, nls: &mut Socket) -> Result<(), ProxyError> {
+        debug!("adding gateways to {}", self.interface);
+        match core_utils::add_default_routes(nls, &*self.gateways) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(ProxyError::new(e.to_string())),
+        }
+    }
+
+    /*
+       For now, nv will remove the interface; this causes all IP stuff
+       to fold.
+    */
+    fn remove(self) -> Result<(), ProxyError> {
+        debug!("removing interface {}", self.interface);
+        todo!()
+    }
+}
+
+// setup takes the DHCP lease and some additional information and
+// applies the TCP/IP information to the namespace.
+pub fn setup(lease: &NetavarkLease, interface: &str, ns_path: &str) -> Result<(), ProxyError> {
+    debug!("setting up {}", interface);
+    let vlan = match MacVLAN::new(lease, interface) {
+        Ok(f) => f,
+        Err(e) => return Err(e),
+    };
+    let (_, mut netns) = core_utils::open_netlink_sockets(ns_path)?;
+    vlan.add_ip(&mut netns.netlink)?;
+    vlan.add_gws(&mut netns.netlink)
+}
+
+// teardown is likely unnecessary but holding place here
+pub fn teardown() -> Result<(), ProxyError> {
+    todo!()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,8 @@ use std::error::Error;
 
 pub mod cache;
 pub mod dhcp_service;
-mod types;
+pub mod ip;
+pub mod types;
 
 use std::fs::File;
 // TODO these constant destinations are not final.
@@ -31,13 +32,6 @@ pub mod g_rpc {
         }
     }
 
-    impl DhcpV4Lease {
-        /// update the host name. This is only applicable to dhcpv4 leases
-        pub fn add_host_name(&mut self, host_name: String) {
-            self.host_name = host_name;
-        }
-    }
-
     impl From<MozimV4Lease> for Lease {
         fn from(l: MozimV4Lease) -> Lease {
             // Since these fields are optional as per mozim. Match them first and then set them
@@ -54,19 +48,16 @@ pub mod g_rpc {
                 mtu,
                 domain_name,
                 mac_address: "".to_string(),
-                v4: Some(DhcpV4Lease {
-                    siaddr: l.siaddr.to_string(),
-                    yiaddr: l.yiaddr.to_string(),
-                    srv_id: l.srv_id.to_string(),
-                    subnet_mask: l.subnet_mask.to_string(),
-                    // TODO something is jacked with8 broadcast, moving on
-                    broadcast_addr: "".to_string(),
-                    dns_servers: handle_ip_vectors(l.dns_srvs),
-                    gateways: handle_ip_vectors(l.gateways),
-                    ntp_servers: handle_ip_vectors(l.ntp_srvs),
-                    host_name: l.host_name.unwrap_or_else(|| String::from("")),
-                }),
-                v6: None,
+                siaddr: l.siaddr.to_string(),
+                yiaddr: l.yiaddr.to_string(),
+                srv_id: l.srv_id.to_string(),
+                subnet_mask: l.subnet_mask.to_string(),
+                // TODO something is jacked with8 broadcast, moving on
+                broadcast_addr: "".to_string(),
+                dns_servers: handle_ip_vectors(l.dns_srvs),
+                gateways: handle_ip_vectors(l.gateways),
+                ntp_servers: handle_ip_vectors(l.ntp_srvs),
+                host_name: l.host_name.unwrap_or_else(|| String::from("")),
                 is_v6: false,
             }
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,9 @@
+use ipnet::PrefixLenError;
+use netavark::error::NetavarkError;
 use std::num::ParseIntError;
 use std::str::FromStr;
+use std::string::ToString;
+use tonic::{Code, Status};
 
 use crate::NetworkConfig;
 impl FromStr for NetworkConfig {
@@ -8,7 +12,6 @@ impl FromStr for NetworkConfig {
     fn from_str(_s: &str) -> Result<Self, Self::Err> {
         // s is actually a string so if we intend to generate
         // a `NetworkConfig` object from `s` parse `s` and populate
-        // ifcace, mac_addr, domain_name, host_name and version
         // instead of default empty values
         Ok(NetworkConfig {
             iface: "".to_string(),
@@ -16,6 +19,44 @@ impl FromStr for NetworkConfig {
             domain_name: "".to_string(),
             host_name: "".to_string(),
             version: 0,
+            ns_path: "".to_string(),
         })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ProxyError(String);
+
+pub trait CustomErr {
+    fn new(msg: String) -> Self;
+}
+
+impl CustomErr for ProxyError {
+    fn new(msg: String) -> Self {
+        ProxyError(msg)
+    }
+}
+
+impl ToString for ProxyError {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl From<ProxyError> for Status {
+    fn from(pe: ProxyError) -> Self {
+        Status::new(Code::Unknown, pe.to_string())
+    }
+}
+
+impl From<NetavarkError> for ProxyError {
+    fn from(cause: NetavarkError) -> Self {
+        ProxyError::new(cause.to_string())
+    }
+}
+
+impl From<PrefixLenError> for ProxyError {
+    fn from(cause: PrefixLenError) -> Self {
+        ProxyError::new(cause.to_string())
     }
 }

--- a/test/002-setup.bats
+++ b/test/002-setup.bats
@@ -6,21 +6,26 @@
 load helpers
 
 @test "basic setup" {
+
       read -r -d '\0' input_config <<EOF
 {
   "iface": "veth0",
   "mac_addr": "3c:e1:a1:c1:7a:3f",
   "domain_name": "example.com",
   "host_name": "foobar",
-  "version": 0
+  "version": 0,
+  "ns_path": "$NS_PATH"
 }
   \0
 EOF
 
         run_setup "$input_config"
         # Check that gateway provided is the first IP in the subnet
-        assert `echo "$output" | jq -r .v4.siaddr` == $(gateway_from_subnet "$SUBNET_CIDR")
+        assert `echo "$output" | jq -r .siaddr` == $(gateway_from_subnet "$SUBNET_CIDR")
+        container_ip=$(echo "$output" | jq -r .yiaddr)
+        has_ip "$container_ip"
 }
+
 
 @test "empty interface should fail" {
       read -r -d '\0' input_config <<EOF
@@ -29,7 +34,8 @@ EOF
   "mac_addr": "3c:e1:a1:c1:7a:3f",
   "domain_name": "example.com",
   "host_name": "foobar",
-  "version": 0
+  "version": 0,
+  "ns_path": "$NS_PATH"
 }
   \0
 EOF
@@ -45,7 +51,8 @@ EOF
   "mac_addr": "",
   "domain_name": "example.com",
   "host_name": "foobar",
-  "version": 0
+  "version": 0,
+  "ns_path": "$NS_PATH"
 }
   \0
 EOF
@@ -61,7 +68,8 @@ EOF
   "mac_addr": "",
   "domain_name": "example.com",
   "host_name": "foobar",
-  "version": 0
+  "version": 0,
+  "ns_path": "$NS_PATH"
 }
   \0
 EOF
@@ -77,7 +85,8 @@ EOF
   "mac_addr": "123",
   "domain_name": "example.com",
   "host_name": "foobar",
-  "version": 0
+  "version": 0,
+  "ns_path": "$NS_PATH"
 }
   \0
 EOF

--- a/test/003-teardown.bats
+++ b/test/003-teardown.bats
@@ -13,7 +13,8 @@ load helpers
   "mac_addr": "${random_mac}",
   "domain_name": "example.com",
   "host_name": "foobar",
-  "version": 0
+  "version": 0,
+  "ns_path": "$NS_PATH"
 }
   \0
 EOF


### PR DESCRIPTION
When the server obtains a lease for a container, it needs to enter the container's namespace and do the IP and route setup.  This uses recent netavark refactorings to call netlink with friendly apis in nv.

Signed-off-by: Brent Baude <bbaude@redhat.com>