### PR TITLE
Allow connections from netavark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ name = "client"
 path = "src/client/client.rs"
 
 [dependencies]
-serde = { version = "1.0.143", features = ["derive"] }
+serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.83"
-mozim = { git = "https://github.com/nispor/mozim", rev="553dea9" }
+mozim = { git = "https://github.com/nispor/mozim"}
 tonic = "0.8"
 prost = "0.11"
 futures-core = "0.3"
@@ -31,7 +31,7 @@ clap = { version = "3.0.12", features = ["derive"] }
 env_logger = "0.9.1"
 http = "0.2.8"
 macaddr = "1.0.1"
-netavark = { git = "https://github.com/containers/netavark", rev="0b04857d9b3eea88029a1f03f418a2384913f679"}
+netavark = { git = "https://github.com/containers/netavark"}
 rtnetlink = "0.11.0" 
 ipnet = { version = "2", features = ["serde"] }
 

--- a/proto/proxy.proto
+++ b/proto/proxy.proto
@@ -8,8 +8,9 @@ service NetavarkProxy {
 }
 // Netavark sends the proxy the Network Configuration that it wants to setup
 message NetworkConfig {
-  string iface = 1;
-  string mac_addr = 3;
+  string host_iface = 1;
+  string container_iface = 2;
+  string container_mac_addr = 3;
   string domain_name = 4;
   string host_name = 5;
   Version version = 6;

--- a/src/client/commands/setup.rs
+++ b/src/client/commands/setup.rs
@@ -1,9 +1,7 @@
 use clap::Parser;
 use log::debug;
-use netavark_proxy::g_rpc::netavark_proxy_client::NetavarkProxyClient;
 use netavark_proxy::g_rpc::{Lease, NetworkConfig};
-use tonic::transport::Channel;
-use tonic::{Request, Response, Status};
+use tonic::Status;
 
 #[derive(Parser, Debug)]
 pub struct Setup {
@@ -17,15 +15,13 @@ impl Setup {
         Self { config }
     }
 
-    pub async fn exec(
-        &self,
-        mut conn: NetavarkProxyClient<Channel>,
-    ) -> Result<Response<Lease>, Status> {
+    pub async fn exec(&self, p: &str) -> Result<Lease, Status> {
         debug!("{:?}", "Setting up...");
         debug!(
             "input: {:#?}",
             serde_json::to_string_pretty(&self.config.clone())
         );
-        conn.setup(Request::new(self.config.clone())).await
+
+        self.config.clone().get_lease(p).await
     }
 }

--- a/src/client/commands/teardown.rs
+++ b/src/client/commands/teardown.rs
@@ -1,9 +1,7 @@
 use clap::Parser;
 use log::debug;
-use netavark_proxy::g_rpc::netavark_proxy_client::NetavarkProxyClient;
 use netavark_proxy::g_rpc::{Lease, NetworkConfig};
-use tonic::transport::Channel;
-use tonic::{Request, Response, Status};
+use tonic::Status;
 
 #[derive(Parser, Debug)]
 pub struct Teardown {
@@ -17,11 +15,8 @@ impl Teardown {
         Self { config }
     }
 
-    pub async fn exec(
-        &self,
-        mut conn: NetavarkProxyClient<Channel>,
-    ) -> Result<Response<Lease>, Status> {
+    pub async fn exec(&self, p: &str) -> Result<Lease, Status> {
         debug!("Entering teardown");
-        conn.teardown(Request::new(self.config.clone())).await
+        self.config.clone().drop_lease(p).await
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,12 +14,13 @@ impl FromStr for NetworkConfig {
         // a `NetworkConfig` object from `s` parse `s` and populate
         // instead of default empty values
         Ok(NetworkConfig {
-            iface: "".to_string(),
-            mac_addr: "".to_string(),
+            host_iface: "".to_string(),
+            container_mac_addr: "".to_string(),
             domain_name: "".to_string(),
             host_name: "".to_string(),
             version: 0,
             ns_path: "".to_string(),
+            container_iface: "".to_string(),
         })
     }
 }

--- a/test/002-setup.bats
+++ b/test/002-setup.bats
@@ -9,8 +9,9 @@ load helpers
 
       read -r -d '\0' input_config <<EOF
 {
-  "iface": "veth0",
-  "mac_addr": "3c:e1:a1:c1:7a:3f",
+  "host_iface": "veth1",
+  "container_iface": "veth0",
+  "container_mac_addr": "$CONTAINER_MAC",
   "domain_name": "example.com",
   "host_name": "foobar",
   "version": 0,
@@ -27,11 +28,12 @@ EOF
 }
 
 
-@test "empty interface should fail" {
+@test "empty interface should fail 155" {
       read -r -d '\0' input_config <<EOF
 {
-  "iface": "",
-  "mac_addr": "3c:e1:a1:c1:7a:3f",
+  "container_iface": "",
+  "host_iface": "veth1",
+  "container_mac_addr": "$CONTAINER_MAC",
   "domain_name": "example.com",
   "host_name": "foobar",
   "version": 0,
@@ -41,14 +43,15 @@ EOF
 EOF
         # Not providing an interface in the config should result
         # in an error and a return code of 156
-        expected_rc=156 run_setup "$input_config"
+        expected_rc=155 run_setup "$input_config"
 }
 
-@test "empty mac address should fail" {
+@test "empty mac address should fail 156" {
       read -r -d '\0' input_config <<EOF
 {
-  "iface": "veth0",
-  "mac_addr": "",
+  "container_iface": "veth0",
+  "container_mac_addr": "",
+  "host_iface": "veth1",
   "domain_name": "example.com",
   "host_name": "foobar",
   "version": 0,
@@ -61,11 +64,12 @@ EOF
         expected_rc=156 run_setup "$input_config"
 }
 
-@test "invalid interface should fail" {
+@test "invalid interface should fail 156" {
       read -r -d '\0' input_config <<EOF
 {
-  "iface": "veth0",
-  "mac_addr": "",
+  "container_iface": "veth990",
+  "host_iface": "veth1",
+  "container_mac_addr": "",
   "domain_name": "example.com",
   "host_name": "foobar",
   "version": 0,
@@ -78,11 +82,12 @@ EOF
         expected_rc=156 run_setup "$input_config"
 }
 
-@test "invalid mac address should fail" {
+@test "invalid mac address should fail 156" {
       read -r -d '\0' input_config <<EOF
 {
-  "iface": "veth0",
-  "mac_addr": "123",
+  "container_iface": "veth0",
+  "host_iface": "veth1",
+  "container_mac_addr": "123",
   "domain_name": "example.com",
   "host_name": "foobar",
   "version": 0,

--- a/test/003-teardown.bats
+++ b/test/003-teardown.bats
@@ -6,11 +6,11 @@
 load helpers
 
 @test "basic teardown" {
-  random_mac=$(generate_mac)
       read -r -d '\0' input_config <<EOF
 {
-  "iface": "veth0",
-  "mac_addr": "${random_mac}",
+  "host_iface": "veth1",
+  "container_iface": "veth0",
+  "container_mac_addr": "${CONTAINER_MAC}",
   "domain_name": "example.com",
   "host_name": "foobar",
   "version": 0,
@@ -25,7 +25,7 @@ EOF
        before=$output
        # Check that our mac address is in the lease file which
        # ensures that it was added
-       run_helper jq "has(\"$random_mac\")" <<<"$before"
+       run_helper jq "has(\"$CONTAINER_MAC\")" <<<"$before"
        assert "$output" == "true"
        # Run teardown
        run_teardown "$input_config"

--- a/test/004-server.bats
+++ b/test/004-server.bats
@@ -5,11 +5,11 @@
 
 load helpers
 @test "SIGINT Clean up" {
-  random_mac=$(generate_mac)
       read -r -d '\0' input_config <<EOF
 {
-  "iface": "veth0",
-  "mac_addr": "${random_mac}",
+  "host_iface": "veth1",
+  "container_iface": "veth0",
+  "container_mac_addr": "${CONTAINER_MAC}",
   "domain_name": "example.com",
   "host_name": "foobar",
   "version": 0
@@ -24,11 +24,10 @@ expected_rc=2 run_helper ls -l "$TMP_TESTDIR/socket"
 }
 
 @test "SIGTERM Clean up" {
-random_mac=$(generate_mac)
 read -r -d '\0' input_config <<EOF
 {
     "iface": "veth0",
-    "mac_addr": "${random_mac}",
+    "mac_addr": "${CONTAINER_MAC}",
     "domain_name": "example.com",
     "host_name": "foobar",
     "version": 0

--- a/test/configfiles/bad_interface.json
+++ b/test/configfiles/bad_interface.json
@@ -1,5 +1,5 @@
 {
-  "iface": "badinterfacename",
+  "host_iface": "badinterfacename",
   "mac_addr": "3c:e1:a1:c1:7a:3f",
   "domain_name": "example.com",
   "host_name": "foobar",

--- a/test/configfiles/bad_mac.json
+++ b/test/configfiles/bad_mac.json
@@ -1,5 +1,5 @@
 {
-  "iface": "veth0",
+  "host_iface": "veth0",
   "mac_addr": "3c:e1:a1a:3f",
   "domain_name": "example.com",
   "host_name": "foobar",

--- a/test/configfiles/basic.json
+++ b/test/configfiles/basic.json
@@ -1,7 +1,10 @@
 {
-  "iface": "veth0",
-  "mac_addr": "3c:e1:a1:c1:7a:3f",
+  "host_iface": "veth1",
+  "container_iface": "veth0",
+  "container_mac_addr": "66:c0:05:74:df:d0",
+  "host_mac_addr": "56:dc:88:28:b1:93",
   "domain_name": "example.com",
   "host_name": "foobar",
-  "version": 0
+  "version": 0,
+  "ns_path": "/run/netns/foobar"
 }

--- a/test/configfiles/no_mac.json
+++ b/test/configfiles/no_mac.json
@@ -1,5 +1,5 @@
 {
-  "iface": "veth0",
+  "host_iface": "veth0",
   "mac_addr": "",
   "domain_name": "example.com",
   "host_name": "foobar",

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -1,11 +1,12 @@
 # -*- bash -*-
 
-PROXY_PID=
-TMP_TESTDIR=
+CONTAINER_MAC=
 DNSMASQ_PIDFILE=
-SUBNET_CIDR=
-NS_PATH=
 NS_NAME=
+NS_PATH=
+PROXY_PID=
+SUBNET_CIDR=
+TMP_TESTDIR=
 
 
 # Netavark binary to run
@@ -270,6 +271,9 @@ function basic_setup() {
   set_tmpdir
   add_bridge "br0"
   add_veth "veth0" "br0"
+  run_in_container_netns ip -j link show veth0
+  CONTAINER_MAC=$(echo "$output" | jq -r .[0].address)
+  add_veth "veth1" "br0"
   run_in_container_netns ip link set lo up
   run_dhcp "$TESTSDIR/dnsmasqfiles"
   DNSMASQ_PID="$output"


### PR DESCRIPTION
Preparatory code for allow netavark to call into the grpc proxy and return the correct results.  we also now assign the proper ip address and subnet mask and gateway into the netns.

System tests are pending and will be added later.

Signed-off-by: Brent Baude <bbaude@redhat.com>