### PR TITLE
Send DHCP release on teardown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/client/client.rs"
 [dependencies]
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.83"
-mozim = { git = "https://github.com/nispor/mozim"}
+mozim = "0.1"
 tonic = "0.8"
 prost = "0.11"
 futures-core = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,7 @@ fn main() {
         .type_attribute("netavark_proxy.DhcpV6Lease", "#[derive(serde::Serialize)]")
         .type_attribute("netavark_proxy.IPResponse", "#[derive(serde::Serialize)]")
         .type_attribute("netavark_proxy.MacAddress", "#[derive(serde::Serialize)]")
-        .type_attribute("netavark_proxy.Ipv4Addr", "#[derive(serde::Serialize)]")
+        .type_attribute("netavark_proxy.NvIpv4Addr", "#[derive(serde::Serialize)]")
         .type_attribute("netavark_proxy.Lease", "#[derive(serde::Deserialize)]")
         .type_attribute(
             "netavark_proxy.DhcpV4Lease",
@@ -21,7 +21,7 @@ fn main() {
         )
         .type_attribute("netavark_proxy.IPResponse", "#[derive(serde::Deserialize)]")
         .type_attribute("netavark_proxy.MacAddress", "#[derive(serde::Deserialize)]")
-        .type_attribute("netavark_proxy.Ipv4Addr", "#[derive(serde::Deserialize)]")
+        .type_attribute("netavark_proxy.NvIpv4Addr", "#[derive(serde::Deserialize)]")
         .type_attribute("netavark_proxy.MacAddress", "#[derive(Eq)]")
         .type_attribute("netavark_proxy.MacAddress", "#[derive(Hash)]")
         .type_attribute(

--- a/contrib/script/basic.sh
+++ b/contrib/script/basic.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# This is just a helper for testing dhcp macvlan and the proxy.  It
+# can be used to generate a config file for the proxy-client to read
+# in. i.e. this is what netavark would be sending.
+#
+
+if [ "$#" -ne 3 ]; then
+    echo "usage: basic.sh <host_ifc> <netns> <netns_ifc>"
+    exit 1
+fi
+
+inside_mac=$(ip netns exec ${2} cat /sys/class/net/${3}/address)
+
+
+read -r -d '\0' input_config <<EOF
+
+{
+  "host_iface": "${1}",
+  "container_iface": "${3}",
+  "container_mac_addr": "${inside_mac}",
+  "domain_name": "example.com",
+  "host_name": "foobar",
+  "version": 0,
+  "ns_path": "/run/netns/$2"
+}
+  \0
+EOF
+
+ echo "$input_config" | jq
+

--- a/proto/proxy.proto
+++ b/proto/proxy.proto
@@ -50,10 +50,10 @@ enum Version {
   V6 = 1;
 }
 
-message Ipv4Addr {
+message NvIpv4Addr {
   bytes octets = 1;
 }
 
-message Ipv6Addr {
+message NvIpv6Addr {
   bytes octets = 1;
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,8 @@
 use ipnet::PrefixLenError;
+use mozim::DhcpError;
+use mozim::ErrorKind::InvalidArgument;
 use netavark::error::NetavarkError;
+use std::net::AddrParseError;
 use std::num::ParseIntError;
 use std::str::FromStr;
 use std::string::ToString;
@@ -59,5 +62,17 @@ impl From<NetavarkError> for ProxyError {
 impl From<PrefixLenError> for ProxyError {
     fn from(cause: PrefixLenError) -> Self {
         ProxyError::new(cause.to_string())
+    }
+}
+
+impl From<AddrParseError> for ProxyError {
+    fn from(e: AddrParseError) -> Self {
+        ProxyError::new(e.to_string())
+    }
+}
+
+impl From<ProxyError> for DhcpError {
+    fn from(e: ProxyError) -> Self {
+        DhcpError::new(InvalidArgument, e.to_string())
     }
 }

--- a/test/README-manual_test.md
+++ b/test/README-manual_test.md
@@ -1,0 +1,82 @@
+# How to test the proxy and client manually
+
+The following instructions can help you manually test the proxy server and client.  You will need dnsmasq which
+is used for DHCP services only.
+
+## Setup network and namespace
+
+The first step is to set up an example virtual network with a bridge.  Then one of the virtual ethernet devices
+needs to be put into a netns.  The following should suffice:
+
+```
+$ ip netns add new
+$ ip link add dev outside type veth peer name outsidebr
+$ ip link add dev inside type veth peer name insidebr
+$ ip link add brtest type bridge
+$ ip addr add 172.172.1.1/24 dev brtest
+$ ip link set outsidebr master brtest
+$ ip link set insidebr master brtest
+$ ip link set brtest up
+$ ip link set inside netns new
+$ ip link set outsidebr up
+$ ip link set insidebr up
+$ ip addr add 172.172.1.2/24 dev outside
+$ ip link set outside up
+$ ip netns exec new ip link set lo up
+$ ip netns exec new ip link set inside up
+```
+
+Verify that all the interfaces are status of UP using `ip a` and `ip netns exec new ip a`.
+
+## Start DNSMasq
+
+Open a terminal and from the git repository, edit *test/dnsmasqfiles/sample.conf*.  Make sure the interface
+matches the interface of the bridge (brtest) in this case.
+
+```
+# Set the interface on which dnsmasq operates.
+# If not set, all the interfaces is used.
+interface=brtest
+
+# To disable dnsmasq's DNS server functionality.
+port=0
+...
+```
+
+```
+$ sudo dnsmasq  -d --log-debug --log-queries --conf-dir test/dnsmasqfiles
+```
+
+## Start the nv-proxy server
+
+Open another terminal and build the server and client
+
+```
+$ make all
+```
+
+Then run the server with debug enabled:
+
+```
+$ sudo RUST_LOG=debug ./bin/netavark-proxy
+```
+
+Note: When doing debug of the client or server, it can be very nice to run the server in your IDE.  This allows
+you to set breakpoints and see variable values. Here is an example of doing this with CLion.
+
+![CLION setup](IDE.png)
+
+## Run the client
+
+In another terminal, you can then run the client.  You need to generate a config file first.  A script is provided
+that will generate a basic config file for you. The script needs the interface name of the bridge, the name of the
+netns, and the name of the interface inside the netns respectively.  Simply pipe the output to a file.
+
+```
+$ sudo sh ./contrib/script/basic.sh brtest new inside
+```
+
+Then run the client with debug enabled:
+```
+$ sudo RUST_LOG=debug ./bin/client -f <path_to_config> setup|teardown foo
+```

--- a/test/dnsmasqfiles/sample.conf
+++ b/test/dnsmasqfiles/sample.conf
@@ -1,6 +1,6 @@
 # Set the interface on which dnsmasq operates.
 # If not set, all the interfaces is used.
-interface=br0
+interface=brtest
 
 # To disable dnsmasq's DNS server functionality.
 port=0


### PR DESCRIPTION
When we teardown a dhcp macvlan, it is considered good practice to send a DHCP release message to the server that provided the lease.

changed the return type of remove_lease to return a copy of the lease so it can be used to send the release message.

added readme for manual testing

Signed-off-by: Brent Baude <bbaude@redhat.com>