### PR TITLE
Implement cache testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ macaddr = "1.0.1"
 nv = { package = "netavark", version  = "1.4"}
 rtnetlink = "0.11.0" 
 ipnet = { version = "2", features = ["serde"] }
+rand = "0.8.5"
 
 [dev-dependencies]
 once_cell = "1.8.0"

--- a/src/dhcp_service.rs
+++ b/src/dhcp_service.rs
@@ -1,4 +1,5 @@
 use crate::dhcp_service::DhcpServiceErrorKind::{Bug, InvalidArgument, NoLease, Timeout};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use crate::g_rpc::{Lease as NetavarkLease, Lease, NetworkConfig};
 use log::warn;
@@ -42,6 +43,32 @@ pub struct DhcpService {
     client: Option<DhcpClient>,
     network_config: NetworkConfig,
     timeout: isize,
+}
+
+trait IP4Conv {
+    fn from(self) -> Ipv4Addr;
+}
+
+impl IP4Conv for IpAddr {
+    fn from(self) -> Ipv4Addr {
+        if let IpAddr::V4(ipv4) = self {
+            return ipv4;
+        }
+        Ipv4Addr::from(0)
+    }
+}
+
+trait IP6Conv {
+    fn from(self) -> Ipv6Addr;
+}
+
+impl IP6Conv for IpAddr {
+    fn from(self) -> Ipv6Addr {
+        if let IpAddr::V6(ipv6) = self {
+            return ipv6;
+        }
+        Ipv6Addr::from(0)
+    }
 }
 
 impl DhcpService {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate core;
+
 use crate::g_rpc::{Lease, NetworkConfig};
 use std::error::Error;
 

--- a/test/configfiles/basic.json
+++ b/test/configfiles/basic.json
@@ -2,7 +2,6 @@
   "host_iface": "veth1",
   "container_iface": "veth0",
   "container_mac_addr": "66:c0:05:74:df:d0",
-  "host_mac_addr": "56:dc:88:28:b1:93",
   "domain_name": "example.com",
   "host_name": "foobar",
   "version": 0,

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -1,0 +1,15 @@
+ip netns add new
+ip link add dev outside type veth peer name outsidebr
+ip link add dev inside type veth peer name insidebr
+ip link add brtest type bridge
+ip addr add 172.172.1.1/24 dev brtest
+ip link set outsidebr master brtest
+ip link set insidebr master brtest
+ip link set brtest up
+ip link set inside netns new
+ip link set outsidebr up
+ip link set insidebr up
+ip addr add 172.172.1.2/24 dev outside
+ip link set outside up
+ip netns exec new ip link set lo up
+ip netns exec new ip link set inside up


### PR DESCRIPTION
Changed cache to no longer take a file and instead take a writer.

Allows for testing of caching module inside of memory. Finsihed testing for add_lease, remove_lease, and update_lease

Signed-off-by: Jack <jackbaude@gmail.com>