### PR TITLE
Version mozim and netavark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/client/client.rs"
 [dependencies]
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.83"
-mozim = { git = "https://github.com/nispor/mozim"}
+mozim = "0.1"
 tonic = "0.8"
 prost = "0.11"
 futures-core = "0.3"
@@ -31,7 +31,7 @@ clap = { version = "3.0.12", features = ["derive"] }
 env_logger = "0.10.0"
 http = "0.2.8"
 macaddr = "1.0.1"
-netavark = { git = "https://github.com/containers/netavark"}
+netavark = "1.4"
 rtnetlink = "0.11.0" 
 ipnet = { version = "2", features = ["serde"] }
 


### PR DESCRIPTION
No longer use git releases of mozim and netavark

Signed-off-by: Brent Baude <bbaude@redhat.com>