### PR TITLE
Import netavark as nv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ clap = { version = "3.0.12", features = ["derive"] }
 env_logger = "0.10.0"
 http = "0.2.8"
 macaddr = "1.0.1"
-netavark = "1.4"
+nv = { package = "netavark", version  = "1.4"}
 rtnetlink = "0.11.0" 
 ipnet = { version = "2", features = ["serde"] }
 

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -1,5 +1,3 @@
-// use netavark::network::core_utils::CoreUtils;
-
 /*
    This file is intended to support netavark-dhcp-proxy configuring the IP information
    that it got from the dhcp server.
@@ -11,9 +9,9 @@ use crate::g_rpc::{Lease as NetavarkLease, Lease};
 use crate::types::{CustomErr, ProxyError};
 use ipnet::IpNet;
 use log::debug;
-use netavark::network::core_utils;
-use netavark::network::netlink;
-use netavark::network::netlink::Socket;
+use nv::network::core_utils;
+use nv::network::netlink;
+use nv::network::netlink::Socket;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 use ipnet::PrefixLenError;
 use mozim::DhcpError;
 use mozim::ErrorKind::InvalidArgument;
-use netavark::error::NetavarkError;
+use nv::error::NetavarkError;
 use std::net::AddrParseError;
 use std::num::ParseIntError;
 use std::str::FromStr;


### PR DESCRIPTION
to avoid circular dependency issues where netavark also uses nv-proxy which also uses netavark, we alias in Cargo.toml.

Signed-off-by: Brent Baude <bbaude@redhat.com>