### PR TITLE
Add inactivity timeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1.0.83"
 mozim = "0.1"
 tonic = "0.8"
 prost = "0.11"
+futures-channel="0.3"
 futures-core = "0.3"
 futures-util = "0.3"
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "sync", "time", "net", "fs", "signal"] }

--- a/docs/netavark-dhcp-proxy.md
+++ b/docs/netavark-dhcp-proxy.md
@@ -17,13 +17,18 @@ DHCP and MacVLAN networking.
 
 ## GLOBAL OPTIONS
 
+#### **--activity-timeout, -a**
+Time in seconds when the proxy should exit if it has no leases.  The default time
+is *300* seconds. A value of *0* disables the activity timeout.
+
 #### **--dir**=*path*
 
 The directory option is a path to store the lease backup files. The default is
-*/var/tmp/nv-proxy*.
+*/run/podman/*.  The lease name is *nv-proxy.leases*.
 
 #### **--uds**
-Set the unix domain socket path instead of using the default.
+Set the unix domain socket directory instead of using the default.  The default is
+*/run/podman*.  The socket name is *nv-proxy.sock*.
 
 #### **--help**, **-h**
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -148,6 +148,18 @@ impl LeaseCache {
         file.sync_all()?;
         Ok(())
     }
+
+    // rust validators require both len and is_empty if you define one
+    // of them
+    pub fn len(&self) -> usize {
+        self.mem.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        if self.len() < 1 {
+            return true;
+        }
+        false
+    }
 }
 
 #[cfg(test)]

--- a/src/proxy_conf.rs
+++ b/src/proxy_conf.rs
@@ -20,6 +20,8 @@ pub const DEFAULT_TIMEOUT: isize = 8;
 pub const PROXY_SOCK_NAME: &str = "nv-proxy.sock";
 // Where leases are stored on the filesystem
 pub const CACHE_FILE_NAME: &str = "nv-proxy.lease";
+// Seconds until the service should exit
+pub const DEFAULT_INACTIVITY_TIMEOUT: u64 = 300;
 
 /// Get the RUN_DIR where the proxy cache and socket
 /// are stored


### PR DESCRIPTION
When the proxy server is run, it shouild exit after a given time of inactivity.  Activity is defined as setup, teardown, or has leases.

An inactivity duration of 0 seconds means NEVER timeout.  The default inactivity timeout is 300 seconds.

Signed-off-by: Brent Baude <bbaude@redhat.com>