### PR TITLE
systemd socket activation

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,7 +19,7 @@ env:
     NETAVARK_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/netavark-dhcp-proxy/success/binary.zip?branch=${NETAVARK_BRANCH}"
     # Save a little typing (path relative to $CIRRUS_WORKING_DIR)
     SCRIPT_BASE: "./contrib/cirrus"
-    IMAGE_SUFFIX: "c6535313974624256"
+    IMAGE_SUFFIX: "c6300530360713216"
     FEDORA_NETAVARK_IMAGE: "fedora-netavark-${IMAGE_SUFFIX}"
 
 

--- a/contrib/systemd/system/netavark-dhcp-proxy.service
+++ b/contrib/systemd/system/netavark-dhcp-proxy.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Netavark DHCP proxy service
+Requires=netavark-dhcp-proxy.socket
+After=netavark-dhcp-proxy.socket
+StartLimitIntervalSec=0
+
+[Service]
+Type=exec
+ExecStart=/usr/libexec/podman/netavark-proxy -a 30
+
+[Install]
+WantedBy=default.target

--- a/contrib/systemd/system/netavark-dhcp-proxy.socket
+++ b/contrib/systemd/system/netavark-dhcp-proxy.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description=Netavark DHCP proxy socket
+
+[Socket]
+ListenStream=%t/podman/nv-proxy.sock
+SocketMode=0660
+
+[Install]
+WantedBy=sockets.target

--- a/hack/get_ci_vm.sh
+++ b/hack/get_ci_vm.sh
@@ -60,9 +60,7 @@ elif [[ "$1" == "--setup" ]]; then
     echo "+ Loading ./contrib/cirrus/lib.sh" > /dev/stderr
     source ./contrib/cirrus/lib.sh
     echo "+ Mimicking .cirrus.yml build_task" > /dev/stderr
-    make install.tools
-    make binaries
-    make docs
+    make all
     echo "+ Running environment setup" > /dev/stderr
     ./contrib/cirrus/setup_environment.sh
 else

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -237,7 +237,7 @@ mod cache_tests {
             let buff = Cursor::new(Vec::new());
             let cache = match LeaseCache::new(buff) {
                 Ok(cache) => cache,
-                Err(e) => panic!("Could not create leases cache: {:?}", e),
+                Err(e) => panic!("Could not create leases cache: {e:?}"),
             };
 
             // Create a random amount of randomized leases
@@ -275,7 +275,7 @@ mod cache_tests {
             let lease_bytes = cache.writer.get_ref().as_slice();
             let s: HashMap<String, Vec<NetavarkLease>> = match serde_json::from_slice(lease_bytes) {
                 Ok(s) => s,
-                Err(e) => panic!("Error: {:?}", e),
+                Err(e) => panic!("Error: {e:?}"),
             };
 
             // Get the mac address of the lease
@@ -318,7 +318,7 @@ mod cache_tests {
             let lease_bytes = cache.writer.get_ref().as_slice();
             let s: HashMap<String, Vec<NetavarkLease>> = match serde_json::from_slice(lease_bytes) {
                 Ok(s) => s,
-                Err(e) => panic!("Error: {:?}", e),
+                Err(e) => panic!("Error: {e:?}"),
             };
 
             // Get the mac address of the lease
@@ -343,7 +343,7 @@ mod cache_tests {
             let lease_bytes = cache.writer.get_ref().as_slice();
             let s: HashMap<String, Vec<NetavarkLease>> = match serde_json::from_slice(lease_bytes) {
                 Ok(s) => s,
-                Err(e) => panic!("Error: {:?}", e),
+                Err(e) => panic!("Error: {e:?}"),
             };
 
             let macaddr = macaddrs
@@ -359,7 +359,7 @@ mod cache_tests {
 
             let removed_lease = cache
                 .remove_lease(macaddr)
-                .unwrap_or_else(|_| panic!("Could not remove {:?} from leases", macaddr));
+                .unwrap_or_else(|_| panic!("Could not remove {macaddr:?} from leases"));
             // Assure the lease is no longer in memory
             assert_eq!(deserialized_lease, removed_lease);
             assert_eq!(s.len(), (range - i) as usize);
@@ -368,7 +368,7 @@ mod cache_tests {
             let lease_bytes = cache.writer.get_ref().as_slice();
             let s: HashMap<String, Vec<NetavarkLease>> = match serde_json::from_slice(lease_bytes) {
                 Ok(s) => s,
-                Err(e) => panic!("Error: {:?}", e),
+                Err(e) => panic!("Error: {e:?}"),
             };
             // There should be no lease under that mac address if the lease was removed
             let no_lease = s.get(macaddr);
@@ -405,7 +405,7 @@ mod cache_tests {
             let lease_bytes = cache.writer.get_ref().as_slice();
             let s: HashMap<String, Vec<NetavarkLease>> = match serde_json::from_slice(lease_bytes) {
                 Ok(s) => s,
-                Err(e) => panic!("Error: {:?}", e),
+                Err(e) => panic!("Error: {e:?}"),
             };
 
             // Get the mac address of the lease
@@ -443,7 +443,7 @@ mod cache_tests {
             let lease_bytes = cache.writer.get_ref().as_slice();
             let s: HashMap<String, Vec<NetavarkLease>> = match serde_json::from_slice(lease_bytes) {
                 Ok(s) => s,
-                Err(e) => panic!("Error: {:?}", e),
+                Err(e) => panic!("Error: {e:?}"),
             };
             // There should be no lease under that mac address if the lease was removed
             let deserialized_updated_lease = s

--- a/src/server.rs
+++ b/src/server.rs
@@ -10,12 +10,14 @@ use netavark_proxy::ip;
 use netavark_proxy::proxy_conf::{
     get_cache_fqname, get_proxy_sock_fqname, DEFAULT_INACTIVITY_TIMEOUT, DEFAULT_TIMEOUT,
 };
-use std::fs;
 use std::fs::File;
 use std::io::Write;
+use std::os::unix::io::FromRawFd;
+use std::os::unix::net::UnixListener as stdUnixListener;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
+use std::{env, fs};
 #[cfg(unix)]
 use tokio::net::UnixListener;
 #[cfg(unix)]
@@ -237,8 +239,22 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Watch for signals after the uds path has been created, so that the socket can be closed.
     handle_signal(uds_path.clone()).await;
 
-    // Bind to the UDS socket for gRPC calls
-    let uds = UnixListener::bind(&uds_path)?;
+    // check if the UDS is a systemd socket activated service.  if it is,
+    // then systemd hands this over to us on FD 3.
+    let uds: UnixListener = match env::var("LISTEN_FDS") {
+        Ok(effds) => {
+            if effds != "1" {
+                error!("Received more than one FD from systemd");
+                return Ok(());
+            }
+            let systemd_socket = unsafe { stdUnixListener::from_raw_fd(3) };
+            systemd_socket.set_nonblocking(true)?;
+            UnixListener::from_std(systemd_socket)?
+        }
+        // Use the standard socket approach
+        Err(..) => UnixListener::bind(&uds_path)?,
+    };
+
     let uds_stream = UnixListenerStream::new(uds);
 
     // Create the cache file


### PR DESCRIPTION
add the ability for the proxy server to take advantage of systemd socket activation so the service does not need to be running by default.

replaces: #24

Signed-off-by: Brent Baude <bbaude@redhat.com>