### PR TITLE
Add testing for identical leases

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -103,7 +103,7 @@ impl<W: Write + Clear + Send + 'static> NetavarkProxy for NetavarkProxyService<W
             if let Err(e) = cache
                 .lock()
                 .expect("Could not unlock cache. A thread was poisoned")
-                .add_lease(&mac_addr, &lease)
+                .upsert_lease(&mac_addr, &lease)
             {
                 return Err(Status::new(
                     Internal,


### PR DESCRIPTION
Merge the add and update lease methods into a upsert method. Add and update used the same logic so it was easier to combine them. Now the upsert will log if it added or updated a lease.

In update and add lease, try adding the same lease immediately after upserting the first. This closes issue #50

Signed-off-by: Jack <jackbaude@gmail.com>